### PR TITLE
fix🐛: 修复跳转失败, 页面未找到问题

### DIFF
--- a/docs/guide/vue-install.md
+++ b/docs/guide/vue-install.md
@@ -1,5 +1,5 @@
 ---
-title: Vue 环境
+title: Node 环境
 order: 80
 toc: content
 ---

--- a/docs/guide/vue-install.md
+++ b/docs/guide/vue-install.md
@@ -9,7 +9,7 @@ toc: content
 
 :::
 
-[老司机绕行](/guide/ksks.html)
+[老司机绕行](/guide/ksks)
 
 ## node.js & npm 安装
 


### PR DESCRIPTION
在文档中vue环境章节中, 点击 老司机绕行 会跳转失败, 修复了这个bug, 现在会正常跳转到快速开始章节